### PR TITLE
Add a "Print box label" button to "My profile"

### DIFF
--- a/infrastructure/config-default.cfg
+++ b/infrastructure/config-default.cfg
@@ -2,3 +2,4 @@ MQTT_HOST="mqtt.bitraf.no"
 MQTT_PORT=1883
 MQTT_PREFIX="public/p2k16-dev/"
 MQTT_PREFIX_TOOL="public/p2k16-dev/tool"
+MQTT_PREFIX_LABEL="public/p2k16-dev/label"

--- a/web/src/p2k16/core/label.py
+++ b/web/src/p2k16/core/label.py
@@ -1,0 +1,57 @@
+import logging
+from datetime import datetime
+from typing import Optional, Mapping, List
+import json
+
+import paho.mqtt.client as mqtt
+from p2k16.core import P2k16UserException, membership_management
+from p2k16.core import account_management, event_management, badge_management
+from p2k16.core.models import db, Account, Circle, Event, Company, ToolDescription, ToolCheckout
+
+logger = logging.getLogger(__name__)
+
+class DummyClient(object):
+    pass
+
+
+class LabelClient(object):
+    def __init__(self, cfg: Mapping[str, str]):
+
+        host = cfg["MQTT_HOST"]
+        port = cfg["MQTT_PORT"]
+        username = cfg["MQTT_USERNAME"]
+        password = cfg["MQTT_PASSWORD"]
+        self.prefix = cfg["MQTT_PREFIX_LABEL"]
+
+        logger.info("Connecting to {}:{}".format(host, port))
+        logger.info("config: username={}, prefix={}".format(username, self.prefix))
+
+        keep_alive = 60
+        c = mqtt.Client()
+        if username:
+            c.username_pw_set(username=username, password=password)
+        c.connect_async(host, port, keep_alive)
+        c.enable_logger()
+        c.loop_start()
+
+        self._client = c
+
+    def _mqtt_topic(self, action):
+        return '/'.join([self.prefix,  action])
+
+
+    def print_box_label(self, account: Account):
+        logger.info("Printing box label for account={}".format(account))
+
+        topic = self._mqtt_topic(action='print_box')
+        payload = json.dumps({"username": account.username,
+            "id": account.id, "name": account.name, "phone": account.phone, "email": account.email})
+
+        logger.info("sending mqtt: {}".format(payload))
+        self._client.publish(topic, payload)
+
+def create_client(cfg: Mapping[str, str]) -> LabelClient:
+    if "MQTT_HOST" not in cfg:
+        logger.info("No MQTT host configured for label, not starting label mqtt client")
+        return DummyClient()
+    return LabelClient(cfg)

--- a/web/src/p2k16/web/label_blueprint.py
+++ b/web/src/p2k16/web/label_blueprint.py
@@ -1,0 +1,49 @@
+import logging
+
+import flask
+import flask_login
+from flask import Blueprint, jsonify, request
+from p2k16.core import P2k16UserException
+from p2k16.core.models import db, Account
+from p2k16.web.utils import validate_schema, DataServiceTool
+
+logger = logging.getLogger(__name__)
+
+label = Blueprint('label', __name__, template_folder='templates')
+registry = DataServiceTool("LabelService", "label-service.js", label)
+
+box_label_form = {
+    "type": "object",
+    "properties": {
+        "user": {"type": "integer"}
+        },
+    "required": ["user"]
+}
+
+@registry.route('/service/label/print_box_label', methods=['POST'])
+@validate_schema(box_label_form)
+@flask_login.login_required
+def print_box_label():
+    a = flask_login.current_user.account
+
+    client = flask.current_app.config.label_client # type: LabelClient
+
+    user = Account.find_account_by_id(request.json["user"])
+
+    client.print_box_label(user)
+
+    return jsonify(dict())
+
+
+@registry.route('/label-service.js')
+def service():
+    content = service.content
+
+    if not content:
+        content = registry.generate()
+        service.content = content
+
+    return content, 'application/javascript'
+
+service.content = None
+

--- a/web/src/p2k16/web/server.py
+++ b/web/src/p2k16/web/server.py
@@ -8,7 +8,7 @@ import flask_login
 import werkzeug.exceptions
 from flask.json import JSONEncoder
 from p2k16.core import P2k16UserException, P2k16TechnicalException, membership_management
-from p2k16.core import make_app, auth, door, mail, tool
+from p2k16.core import make_app, auth, door, mail, tool, label
 from p2k16.core.log import P2k16LoggingFilter
 from p2k16.core.models import db, model_support, P2k16Mixin
 from p2k16.web import utils
@@ -196,8 +196,9 @@ db.init_app(app)
 app.json_encoder = P2k16JSONEncoder
 app.config.door_client = door.create_client(app.config)
 app.config.tool_client = tool.create_client(app.config)
+app.config.label_client = label.create_client(app.config)
 
-from p2k16.web import badge_blueprint, core_blueprint, door_blueprint, tool_blueprint, membership_blueprint
+from p2k16.web import badge_blueprint, core_blueprint, door_blueprint, tool_blueprint, membership_blueprint, label_blueprint
 
 # Inject stripe config parameters
 membership_blueprint.setup_stripe(app.config)
@@ -207,6 +208,7 @@ app.register_blueprint(badge_blueprint.badge)
 app.register_blueprint(core_blueprint.core)
 app.register_blueprint(door_blueprint.door)
 app.register_blueprint(tool_blueprint.tool)
+app.register_blueprint(label_blueprint.label)
 app.register_blueprint(membership_blueprint.membership)
 
 _env = app.config.get("P2K16_ENV", None)

--- a/web/src/p2k16/web/static/my-profile.html
+++ b/web/src/p2k16/web/static/my-profile.html
@@ -41,4 +41,15 @@
     </div>
   </div>
 
+  <h1>Box label</h1>
+  <div class="row">
+    <div class="col-xs-12">
+        <p>Boxes in the member storage area are for paying members only, and they
+        should all have a label with a QR code and basic contact information. Press 
+        here to have a label printed near Bitmart on the second floor, and stick it
+        on your box today</p>
+        <button class="btn btn-default" ng-click="ctrl.printBoxLabel()">Print box label</button>
+    </div>
+  </div>
+
 </div>

--- a/web/src/p2k16/web/static/p2k16/p2k16.js
+++ b/web/src/p2k16/web/static/p2k16/p2k16.js
@@ -728,7 +728,7 @@
      * @param badgeDescriptions
      * @constructor
      */
-    function MyProfileController($scope, P2k16, CoreDataService, badgeDescriptions) {
+    function MyProfileController($scope, P2k16, CoreDataService, badgeDescriptions, LabelService) {
         var self = this;
 
         P2k16.accountListeners.add($scope, function (newValue) {
@@ -747,11 +747,20 @@
             });
         }
 
+
+        function printBoxLabel() {
+            LabelService.print_box_label({'user': P2k16.currentAccount().id}).then(function (res) {
+                var msg = res.message || 'Label sent to printer';
+                P2k16.addInfos(msg);
+            });
+        }
+
         self.badges = [];
         self.newBadge = {};
         self.descriptions = badgeDescriptions;
         self.changePasswordForm = {};
         self.changePassword = changePassword;
+        self.printBoxLabel = printBoxLabel;
 
         updateBadges(P2k16.currentAccount());
     }
@@ -1159,6 +1168,7 @@
         .service("CoreDataService", CoreDataService)
         .service("DoorDataService", DoorDataService)
         .service("ToolDataService", ToolDataService)
+        .service("LabelService", LabelService)
         .service("AuthzService", AuthzService)
         .service("P2k16HttpInterceptor", P2k16HttpInterceptor)
         .filter("yesno", YesNoFilter)

--- a/web/src/p2k16/web/templates/base.html
+++ b/web/src/p2k16/web/templates/base.html
@@ -13,6 +13,7 @@
   <script src="/core-data-service.js"></script>
   <script src="/door-data-service.js"></script>
   <script src="/tool-data-service.js"></script>
+  <script src="/label-service.js"></script>
   <script src="/p2k16_resources.js"></script>
   <script src="{{ url_for('static', filename='p2k16/p2k16.js') }}"></script>
   <link rel="stylesheet" href="{{ url_for('static', filename='bower_components/bootstrap/dist/css/bootstrap.css') }}"/>


### PR DESCRIPTION
The idea is that each member box at bitraf should have a label with a QR
code for quickly checking payment status, and with contact information
if payment has lapsed, making easier to keep the member storage clean
and with some available space.

This code adds a button to your personal profile that lets you print
such a label, by sending a message via MQTT with the information needed
to print a label. Elias is working on the component that will listen for
those messages and do the actual printing and label creation.

The idea of using MQTT is to keep p2k16 low on dependencies, and to not
have it do things that isnt "core".