### PR TITLE
Fix for #61: make it easy to see that a tool is checked out

### DIFF
--- a/web/src/p2k16/web/static/tool-front-page.html
+++ b/web/src/p2k16/web/static/tool-front-page.html
@@ -3,34 +3,19 @@
 <div class="container">
   <h1>Tools</h1>
   <p><a href="https://bitraf.no/wiki/Tool">Click here</a> to read more about the Bitraf Tool system.</p>
-  <div ng-if="ctrl.my_tools.length">
-    <h2>My currently checked out tools</h2>
-    <p>Click a tool to return it</p>
-    <form class="form-horizontal">
-      <table class="table">
-        <tr ng-repeat="tool in ctrl.tools" ng-if="tool.checkout.active">
-          <td class="col-sm-2 text-left">
-            <button ng-if="tool.checkout.active && tool.checkout.account == ctrl.my_account" type="submit" class="btn btn-default" ng-click="ctrl.checkinTool(tool)">{{tool.description}}</button>
-          </td>
-          <td class="col-sm-8">
-            <p ng-if="tool.checkout.active && tool.checkout.account == ctrl.my_account" style="color: red">Checked out since {{tool.checkout.started | date:'medium'}}</p>
-          </td>
-        </tr>
-      </table>
-    </form>
-  </div>
+  
   <h2>Checkout a tool</h2>
   <p>Click a tool to check it out. Always return the tool before you leave. <br /><em>Please note: No tools should ever leave Bitraf, so you cannot "borrow" a tool to work on stuff at home.</em></p>
   <form class="form-horizontal">
     <table class="table">
       <tr ng-repeat="tool in ctrl.tools">
         <td class="col-sm-2 text-left">
-          <button ng-if="tool.checkout.active && tool.checkout.account != ctrl.my_account" type="submit" class="btn btn-default" ng-click="ctrl.checkoutToolConfirm(tool)" id="{{tool.name}} isMine">{{tool.description}}</button>
-          <button ng-if="tool.checkout.active && tool.checkout.account == ctrl.my_account" type="submit" class="btn btn-default" ng-click="ctrl.checkinTool(tool)" id="{{tool.name}} notMine">{{tool.description}}</button>
-          <button ng-if="!tool.checkout.active" type="submit" class="btn btn-default" ng-click="ctrl.checkoutTool(tool)" id="{{tool.name}}">{{tool.description}}</button>
+          <button ng-if="tool.checkout.active && tool.checkout.account != ctrl.my_account" type="submit" class="btn btn-default btn-block btn-danger" ng-click="ctrl.checkoutToolConfirm(tool)" id="{{tool.name}} isMine">{{tool.description}}</button>
+          <button ng-if="tool.checkout.active && tool.checkout.account == ctrl.my_account" type="submit" class="btn btn-default btn-block btn-danger" ng-click="ctrl.checkinTool(tool)" id="{{tool.name}} notMine">{{tool.description}}</button>
+          <button ng-if="!tool.checkout.active" type="submit" class="btn btn-default btn-block" ng-click="ctrl.checkoutTool(tool)" id="{{tool.name}}">{{tool.description}}</button>
         </td>
         <td class="col-sm-8">
-          <p ng-if="tool.checkout.active" style="color: red">In use by {{tool.checkout.username}} since {{tool.checkout.started | date:'medium'}}</p>
+          <p ng-if="tool.checkout.active" style="color: red">Checked out by {{tool.checkout.username}}<br/>{{tool.checkout.started | date:'medium'}}</p>
           <p ng-if="!tool.checkout.active" style="color: green">Available</p>
         </td>
       </div>
@@ -53,5 +38,20 @@
       </span>
     </li>
   </ul>
-
+  <div ng-if="ctrl.my_tools.length">
+    <h2>My currently checked out tools</h2>
+    <p>Click a tool to return it</p>
+    <form class="form-horizontal">
+      <table class="table">
+        <tr ng-repeat="tool in ctrl.tools" ng-if="tool.checkout.active">
+          <td class="col-sm-2 text-left">
+            <button ng-if="tool.checkout.active && tool.checkout.account == ctrl.my_account" type="submit" class="btn btn-default btn-block" ng-click="ctrl.checkinTool(tool)">{{tool.description}}</button>
+          </td>
+          <td class="col-sm-8">
+            <p ng-if="tool.checkout.active && tool.checkout.account == ctrl.my_account" style="color: red">Checked out since {{tool.checkout.started | date:'medium'}}</p>
+          </td>
+        </tr>
+      </table>
+    </form>
+  </div>
 </div>


### PR DESCRIPTION
Adds Block to get even sized buttons. Adds Danger-style to get red buttons for checked out tools. Moved personal checkouts down, since they don't seem to be useful. We can delete them later.