### PR TITLE
fix #51: Order desc when finding last door event

### DIFF
--- a/web/src/p2k16/core/event_management.py
+++ b/web/src/p2k16/core/event_management.py
@@ -101,7 +101,7 @@ def last_door_open(account: Account):
     e = Event.query. \
         filter(Event.created_by == account). \
         filter((Event.domain == "door") & (Event.name == "open")). \
-        order_by(Event.created_at). \
+        order_by(Event.created_at.desc()). \
         limit(1). \
         one_or_none()
 


### PR DESCRIPTION
This makes the page show last seen and not first seen, fixing #51