### PR TITLE
Add polyfill using polyfill-as-a-service

### DIFF
--- a/web/bower.json
+++ b/web/bower.json
@@ -24,7 +24,8 @@
     "angular-stripe-checkout": "^5.1.0",
     "bootstrap": "3.3.7",
     "lodash": "^4.17.4",
-    "spin-js": "2.0.1"
+    "spin-js": "2.0.1",
+    "js-polyfills": "^0.1.42"
   },
   "resolutions": {
     "angular": "1.6.6"

--- a/web/src/p2k16/web/templates/base.html
+++ b/web/src/p2k16/web/templates/base.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <script crossorigin="anonymous" src="https://polyfill.io/v3/polyfill.min.js?flags=gated&features=default%2Ces2015%2Ces2016%2Ces2017%2Ces2018%2Ces5%2Ces6%2Ces7"></script>
+  <script src="{{ url_for('static', filename='bower_components/js-polyfills/polyfill.min.js') }}"></script>
   <script src="{{ url_for('static', filename='bower_components/lodash/dist/lodash.js') }}"></script>
   <script src="{{ url_for('static', filename='bower_components/angular/angular.js') }}"></script>
   <script src="{{ url_for('static', filename='bower_components/angular-i18n/angular-locale_nb-no.js') }}"></script>

--- a/web/src/p2k16/web/templates/base.html
+++ b/web/src/p2k16/web/templates/base.html
@@ -1,6 +1,7 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script crossorigin="anonymous" src="https://polyfill.io/v3/polyfill.min.js?flags=gated&features=default%2Ces2015%2Ces2016%2Ces2017%2Ces2018%2Ces5%2Ces6%2Ces7"></script>
   <script src="{{ url_for('static', filename='bower_components/lodash/dist/lodash.js') }}"></script>
   <script src="{{ url_for('static', filename='bower_components/angular/angular.js') }}"></script>
   <script src="{{ url_for('static', filename='bower_components/angular-i18n/angular-locale_nb-no.js') }}"></script>


### PR DESCRIPTION
This fixes most IE11/Edge and some other issues that stems from using
modern javascript features. Makes it a bit less tedious to write client
code.

We could maintain our own polyfill-library if people dislike external
services, but then we would end up serving the same one to everyone most
likely, which seems like a waste.

Fixes at least #53

https://polyfill.io/v3/url-builder/ to reconfigure or add/remove features.