### PR TITLE
Add timeout for dismissing info-popups

### DIFF
--- a/web/src/p2k16/web/static/p2k16/p2k16.js
+++ b/web/src/p2k16/web/static/p2k16/p2k16.js
@@ -379,12 +379,19 @@
      * @param {SmartCache} BadgeDescriptions
      * @constructor
      */
-    function P2k16($rootScope, Circles, BadgeDescriptions) {
+    function P2k16($rootScope, Circles, BadgeDescriptions, $timeout) {
         var self = this;
         self.$rootScope = $rootScope;
         self.messages = [];
         self.messages.dismiss = function (index) {
             self.messages.splice(index, 1);
+        };
+        self.messages.dismissByText = function (text) {
+            var idx = self.messages.findIndex(function (e) {
+                return e.text === text;
+            });
+
+            self.messages.dismiss(idx);
         };
 
         self.profile = null;
@@ -437,7 +444,16 @@
                 text = typeof(text) === "string" ? text : "";
                 text = text.trim();
                 if (text.length) {
+
                     self.messages.push(new P2k16Message(text, cssClass));
+
+                    if (cssClass === 'alert-info') {
+                        // Lets timeout this message
+                        $timeout(function() {
+                            self.messages.dismissByText(text);
+                        }, 5 * 1000);
+                    }
+
                 }
             }
 


### PR DESCRIPTION
They now disapear after 5 seconds, but that can be adjusted. I chose to
not dismiss error popups by default, since they hopefully are more
important.

This will break in IE11 unless #68 is merged as well

Fixes #65