### PR TITLE
Checks username for `@` and ` ` on signup

### DIFF
--- a/web/src/p2k16/core/account_management.py
+++ b/web/src/p2k16/core/account_management.py
@@ -1,5 +1,7 @@
 import logging
 import string
+import re
+
 from typing import Optional, List
 
 import flask
@@ -176,6 +178,8 @@ def register_account(username: str, email: str, name: str, password: str, phone:
     if " " in username:
         raise P2k16UserException("Username cannot contain spaces")
 
+    if not re.match(r"^[a-zA-Z0-9@._+-]+", username):
+        raise P2k16UserException("Username can only contain a-z, 0-9, @, ., _, + and -.")
 
     account = Account(username, email, name, phone, password)
     db.session.add(account)

--- a/web/src/p2k16/core/account_management.py
+++ b/web/src/p2k16/core/account_management.py
@@ -173,6 +173,9 @@ def register_account(username: str, email: str, name: str, password: str, phone:
     if name is None:
         raise P2k16UserException("Name cannot be empty.")
 
+    if "@" in username:
+        raise P2k16UserException("Username looks like an email, it should be a simple string")
+
     account = Account(username, email, name, phone, password)
     db.session.add(account)
     return account

--- a/web/src/p2k16/core/account_management.py
+++ b/web/src/p2k16/core/account_management.py
@@ -173,9 +173,6 @@ def register_account(username: str, email: str, name: str, password: str, phone:
     if name is None:
         raise P2k16UserException("Name cannot be empty.")
 
-    if "@" in username:
-        raise P2k16UserException("Username looks like an email, it should be a simple string")
-
     if " " in username:
         raise P2k16UserException("Username cannot contain spaces")
 

--- a/web/src/p2k16/core/account_management.py
+++ b/web/src/p2k16/core/account_management.py
@@ -176,6 +176,10 @@ def register_account(username: str, email: str, name: str, password: str, phone:
     if "@" in username:
         raise P2k16UserException("Username looks like an email, it should be a simple string")
 
+    if " " in username:
+        raise P2k16UserException("Username cannot contain spaces")
+
+
     account = Account(username, email, name, phone, password)
     db.session.add(account)
     return account


### PR DESCRIPTION
It seems usernames shouldn't be emails, this blocks this in a crude way
by checking if the username contains `@` and raises an user-exception if
it does, stopping signup with a semi-descriptive error message.

No longer fixes #43, as its not a bug.

Make checks on username stricter in any case, but allow emails.