### PR TITLE
Show membership fee on details page again

### DIFF
--- a/web/src/p2k16/web/static/admin-account-detail.html
+++ b/web/src/p2k16/web/static/admin-account-detail.html
@@ -24,7 +24,7 @@
     </tr>
     <tr>
       <th>Membership fee</th>
-      <td>{{ ctrl.account.account.membership.fee }}</td>
+      <td>{{ ctrl.account.membership.fee }}</td>
     </tr>
     <tr>
       <th>Circles</th>


### PR DESCRIPTION
Probably a bug from the account changes this spring, but there was an
`.account` to much to get the membership details and fee.