### PR TITLE
Show membership fee on public profile page

### DIFF
--- a/web/src/p2k16/web/core_blueprint.py
+++ b/web/src/p2k16/web/core_blueprint.py
@@ -408,6 +408,21 @@ def data_account_summary(account_id):
         "badges": [badge_to_json(b) for b in badges],
         "lastDoorOpen": open_door_event.to_dict() if open_door_event else None,
     }
+
+    # Add information about membership if current user is in a circle
+    admin_circle = Circle.get_by_name('admin')
+    if account_management.is_account_in_circle(flask_login.current_user.account, admin_circle):
+        membership = get_membership(account)
+        membership_details = {}
+        if membership is not None:
+            membership_details['fee'] = membership.fee
+            membership_details['first_membership'] = membership.first_membership
+            membership_details['start_membership'] = membership.start_membership
+        else:
+            membership_details['fee'] = 0
+        summary['membership'] = membership_details
+
+
     return jsonify(summary)
 
 

--- a/web/src/p2k16/web/static/user-detail.html
+++ b/web/src/p2k16/web/static/user-detail.html
@@ -11,6 +11,19 @@
       <p>Last seen: {{ ctrl.summary.lastDoorOpen.created_at | date:'short' }}</p>
     </div>
   </div>
+  <div ng-if="ctrl.summary.membership" class="user-detail-contact-info">
+    <h2 class="text-muted">Membership status <span class="label label-info">admin-only</span></h2>
+    <form class="form-horizontal">
+      <div class="form-group">
+        <label class="col-sm-1 control-label">Fee</label>
+        <div class="col-sm-6">
+          <p class="form-control-static">
+          {{ ctrl.summary.membership.fee }}
+          </p>
+        </div>
+      </div>
+    </form>
+  </div>
 
   <!-- Contact info -->
   <div class="user-detail-contact-info">


### PR DESCRIPTION
This is only shown in the viewer is in the admin circle. It shows
nothing but the fee for now, but first_date and start_date are in the
data sent to the client for admins if that is interesting.