### PR TITLE
Stripe quickfix

### DIFF
--- a/web/src/p2k16/core/mail/__init__.py
+++ b/web/src/p2k16/core/mail/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import os.path
+from typing import Mapping
 
 import emails.loader
 from jinja2 import Template, Environment
@@ -8,9 +9,8 @@ from p2k16.core.models import Account
 
 logger = logging.getLogger(__name__)
 
-mail_from = ('Bitraf', 'root@bitraf.no')
-membership_cc = 'post@bitraf.no'
-
+mail_from = ('Bitraf', 'post@bitraf.no')
+membership_cc = None
 
 class Templates():
     def __init__(self):
@@ -36,6 +36,14 @@ class Templates():
 
 
 _templates = Templates()
+
+
+def setup(cfg: Mapping[str, str]) -> Templates():
+    global membership_cc
+
+    membership_cc = cfg.get('MEMBERSHIP_CC', None)
+
+    return get_templates()  # Preload templates
 
 
 def get_templates() -> Templates:
@@ -66,7 +74,8 @@ def send_new_member(account: Account):
     m = _templates.new_member(account=account)
     m.mail_to = (account.username, account.email)
     m.mail_from = mail_from
-    m.bcc = membership_cc
+    if membership_cc is not None:
+        m.bcc = membership_cc
     m.send()
 
 def send_membership_ended(account: Account):
@@ -75,6 +84,7 @@ def send_membership_ended(account: Account):
     m = _templates.membership_ended(account=account)
     m.mail_to = (account.username, account.email)
     m.mail_from = mail_from
-    m.bcc = membership_cc
+    if membership_cc is not None:
+        m.bcc = membership_cc
     m.send()
 

--- a/web/src/p2k16/core/membership_management.py
+++ b/web/src/p2k16/core/membership_management.py
@@ -204,6 +204,9 @@ def member_customer_portal(account: Account, base_url: str):
     """
     stripe_customer_id = get_stripe_customer(account)
     
+    if stripe_customer_id is None:
+        raise P2k16UserException('No billing information available. Create a subscription first.')
+
     return_url = base_url + '/#!/'
 
     try:

--- a/web/src/p2k16/web/server.py
+++ b/web/src/p2k16/web/server.py
@@ -233,4 +233,4 @@ if _env == "local":
 
 flask_bower.Bower(app)
 
-mail.get_templates()  # Preload templates
+mail.setup(app.config)

--- a/web/src/p2k16/web/static/front-page.html
+++ b/web/src/p2k16/web/static/front-page.html
@@ -79,7 +79,7 @@
   </section>
 
   <!-- Must be moved to menu  -->
-  <section ng-if="ctrl.payingMember">
+  <section>
     <div class="row">
       <div class="col-md-4">
         <button type="button" class="btn btn-info" ng-click="ctrl.manageBilling()">Manage billing</button>


### PR DESCRIPTION
Show Manage billing button at all times. This fixes the case that an expired membership cannot be changed.
Should be better handled on frontend to display a message that membership is active, but unpaid.

Also, enable signup email to be sent to a specific address to avoid spamming post@bitraf.no during testing.