### PR TITLE
Show correct paying member status on profile-page

### DIFF
--- a/web/src/p2k16/web/core_blueprint.py
+++ b/web/src/p2k16/web/core_blueprint.py
@@ -421,6 +421,7 @@ def data_account_summary(account_id):
     if account_management.is_account_in_circle(flask_login.current_user.account, admin_circle):
         logger.debug("{} is in circle {}, will add membership and employment info".format(flask_login.current_user.account, admin_circle))
         membership = get_membership(account)
+        paying_member = StripePayment.is_account_paying_member(account.id)
         membership_details = {}
         if membership is not None:
             membership_details['fee'] = membership.fee
@@ -429,6 +430,7 @@ def data_account_summary(account_id):
         else:
             membership_details['fee'] = 0
         summary['membership'] = membership_details
+        summary['paying_member'] = paying_member
         summary['employment'] = Company.is_account_employed(account.id)
 
 

--- a/web/src/p2k16/web/static/user-detail.html
+++ b/web/src/p2k16/web/static/user-detail.html
@@ -15,15 +15,15 @@
     <h2 class="text-muted">Membership status <span class="label label-info">admin-only</span></h2>
     <form class="form-horizontal">
       <div class="form-group">
-        <label class="col-sm-1 control-label">Fee</label>
+        <label class="col-sm-2 control-label">Paying member</label>
         <div class="col-sm-6">
           <p class="form-control-static">
-          {{ ctrl.summary.membership.fee }}
+          {{ ctrl.summary.paying_member | yesno }}
           </p>
         </div>
       </div>
       <div class="form-group">
-        <label class="col-sm-1 control-label">Employee</label>
+        <label class="col-sm-2 control-label">Employee</label>
         <div class="col-sm-6">
           <p class="form-control-static">
           {{ ctrl.summary.employment|yesno }}


### PR DESCRIPTION
There was a problem with looking at membership, as that is no longer
updated when payment it stopped. Now we simply check StripePayment
and employee-status and show that instead.