### PR TITLE
Add support for different circles for each door

### DIFF
--- a/web/src/p2k16/core/authz_management.py
+++ b/web/src/p2k16/core/authz_management.py
@@ -15,7 +15,7 @@ def can_haz_door_access(account, doors = []):
 
     # Find all circles needed for these doors
 
-    circles = {circle for door in doors for circle in door.circle}
+    circles = {circle for door in doors for circle in door.circles}
 
     # If you lack access to one of the doors attempted, you cant open anything
     access = True

--- a/web/src/p2k16/core/authz_management.py
+++ b/web/src/p2k16/core/authz_management.py
@@ -6,10 +6,27 @@ from p2k16.core.models import Circle, Company
 logger = logging.getLogger(__name__)
 
 
-def can_haz_door_access(account):
-    door_circle = Circle.get_by_name('door')
+def can_haz_door_access(account, doors = []):
 
-    if account_management.is_account_in_circle(account, door_circle) and membership_management.active_member(account):
+    # If called with no doors, this basically checks if you are paying member
+    # or employed at a company. It is used to show the buttons on the front page
+    # for now, in the future, we probably want to make those dependant on access,
+    # so you only see buttons you have access to.
+
+    # Find all circles needed for these doors
+
+    circles = {circle for door in doors for circle in door.circle}
+
+    # If you lack access to one of the doors attempted, you cant open anything
+    access = True
+    for circle in circles:
+        door_circle = Circle.find_by_name(circle)
+        if door_circle is None:
+            access = False
+        elif not account_management.is_account_in_circle(account, door_circle):
+            access = False
+
+    if access and membership_management.active_member(account):
         return True
 
     if Company.is_account_employed(account.id):

--- a/web/src/p2k16/core/door.py
+++ b/web/src/p2k16/core/door.py
@@ -49,7 +49,7 @@ class DoorClient(object):
             logger.info("No dlock base URL configured for door, not starting door dlock client")
 
     def open_doors(self, account: Account, doors):
-        can_open_door = authz_management.can_haz_door_access(account)
+        can_open_door = authz_management.can_haz_door_access(account, doors)
         if not can_open_door:
             f = "{} does not have an active membership, or lacks door circle membership"
             raise P2k16UserException(f.format(account.display_name()))
@@ -84,9 +84,10 @@ def create_client(cfg: Mapping[str, str]) -> DoorClient:
 # dlock  #####################################################################
 
 class DlockDoor(object):
-    def __init__(self, key, open_time):
+    def __init__(self, key, open_time, circle):
         self.key = key
         self.open_time = open_time
+        self.circle = circle
 
 class DlockClient(object):
     def __init__(self, cfg: Mapping[str, str]):
@@ -113,9 +114,10 @@ class DlockClient(object):
 # MQTT  ######################################################################
 
 class MqttDoor(object):
-    def __init__(self, key, open_time, topic):
+    def __init__(self, key, open_time, circle, topic):
         self.key = key
         self.open_time = open_time
+        self.circle = circle
         self.topic = topic
 
 class MqttClient(object):
@@ -149,12 +151,12 @@ class MqttClient(object):
 # Site-specific configuration  ###############################################
 
 _doors = [
-    MqttDoor(   "frontdoor",        10, "frontdoor/open"),
-    MqttDoor(   "2floor",           60, "2floor/open"),
-    MqttDoor(   "3office",          60, "3office/open"),
-    MqttDoor(   "3workshop",        60, "3workshop/open"),
-    MqttDoor(   "4floor",           60, "4floor/open"),
-    DlockDoor(  "bv9-f2-entrance",  10),
+    MqttDoor(   "frontdoor",        10, {"door"}, "frontdoor/open"),
+    MqttDoor(   "2floor",           60, {"door"}, "2floor/open"),
+    MqttDoor(   "3office",          60, {"door"}, "3office/open"),
+    MqttDoor(   "3workshop",        60, {"door"}, "3workshop/open"),
+    MqttDoor(   "4floor",           60, {"door"}, "4floor/open"),
+    DlockDoor(  "bv9-f2-entrance",  10, {"door"}),
 ]
 
 doors = {d.key: d for d in _doors}

--- a/web/src/p2k16/core/door.py
+++ b/web/src/p2k16/core/door.py
@@ -84,10 +84,10 @@ def create_client(cfg: Mapping[str, str]) -> DoorClient:
 # dlock  #####################################################################
 
 class DlockDoor(object):
-    def __init__(self, key, open_time, circle):
+    def __init__(self, key, open_time, circles):
         self.key = key
         self.open_time = open_time
-        self.circle = circle
+        self.circles = circles
 
 class DlockClient(object):
     def __init__(self, cfg: Mapping[str, str]):
@@ -114,10 +114,10 @@ class DlockClient(object):
 # MQTT  ######################################################################
 
 class MqttDoor(object):
-    def __init__(self, key, open_time, circle, topic):
+    def __init__(self, key, open_time, circles, topic):
         self.key = key
         self.open_time = open_time
-        self.circle = circle
+        self.circles = circles
         self.topic = topic
 
 class MqttClient(object):


### PR DESCRIPTION
This allows us to have a set of circles for each door, and without
membership in that circle, you wont be able to open that door.

This check does not apply to employees of companies, only for paying
members.

If you attempt to open multiple doors, none will open if you lack any of
the circles.

For now all doors have `door` only, this is intended used at BV9 to
limit access to certain areas.

https://github.com/bitraf/infrastructure/issues/149