### PR TITLE
More correct door authz handling

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,6 @@ build:
     - echo "$CI_REGISTRY_PASSWORD" | docker login -u $CI_REGISTRY_USER --password-stdin $CI_REGISTRY
     - apk add --no-cache bash git
   script:
-    - bin/p2k16-build -c pull
+    - bin/p2k16-build -c pull || true
     - bin/p2k16-build -c build
     - bin/p2k16-build -c push

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ Flask-Testing==0.8.0
 future==0.18.2
 gunicorn==20.0.4
 idna==2.10
+iniconfig==1.1.1
 itsdangerous==1.1.0
 Jinja2==2.11.3
 jsonschema==3.2.0
@@ -35,11 +36,16 @@ ldif3==3.2.2
 lxml==4.6.3
 MarkupSafe==1.1.1
 nose==1.3.7
+packaging==21.0
 paho-mqtt==1.5.1
+pluggy==1.0.0
 premailer==3.7.0
 psycopg2-binary==2.8.6
+py==1.10.0
 pycparser==2.20
+pyparsing==2.4.7
 pyrsistent==0.17.3
+pytest==6.2.5
 python-dateutil==2.8.1
 PyYAML==5.4
 requests==2.26.0
@@ -48,6 +54,7 @@ SQLAlchemy==1.3.20
 SQLAlchemy-Continuum==1.3.11
 SQLAlchemy-Utils==0.36.8
 stripe==2.55.1
+toml==0.10.2
 typing==3.7.4.3
 urllib3==1.26.6
 Werkzeug==1.0.1

--- a/web/test/p2k16/test_authz_management.py
+++ b/web/test/p2k16/test_authz_management.py
@@ -1,0 +1,96 @@
+import logging
+from unittest import TestCase
+
+from p2k16.core import make_app, account_management, P2k16UserException, authz_management, door
+from p2k16.core.models import *
+
+logger = logging.getLogger(__name__)
+
+
+class P2k16TestCase(TestCase):
+
+    def setUp(self):
+        logger.info("setUp")
+        self.app = make_app()
+
+
+        door.doors["test-door-1"] = door.MqttDoor("test-door-1", 1, {"door"}, "test-door-1/open")
+        door.doors["test-door-2"] = door.MqttDoor("test-door-2", 1, {"bv9-chemist"}, "test-door-2/open")
+        door.doors["test-door-3"] = door.MqttDoor("test-door-3", 1, {"other-circle"}, "test-door-3/open")
+
+        self.app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+
+        self._ctx = self.app.test_request_context()
+        self._ctx.push()
+
+        db.init_app(self.app)
+        db.create_all()
+
+        logger.info("setUp done")
+
+    def tearDown(self):
+        self._ctx.pop()
+        logger.info("tearDown")
+
+
+# noinspection PyMethodMayBeStatic
+class DoorAccessTest(P2k16TestCase):
+
+    def test_door_access(self):
+        session = db.session
+
+        a1 = Account('door-account1', 'door-account1@example.org', password='123')
+        a2 = Account('door-account2', 'door-account2@example.org', password='123')
+        a3 = Account('door-account3', 'door-account3@example.org', password='123')
+        session.add_all([a1, a2, a3])
+        session.flush()
+        with model_support.run_as(a1):
+
+            m1 = Membership(500)
+            payment1 = StripePayment('tok_stripe_xx1339', datetime(2017, 3, 1),
+                                     datetime.now() + timedelta(days=10), '500.00', datetime(2017, 2, 1))
+            session.add_all([m1, payment1])
+
+        with model_support.run_as(a2):
+            m2 = Membership(500)
+            payment2 = StripePayment('tok_stripe_xx1348', datetime(2017, 3, 1),
+                                     datetime.now() + timedelta(days=10), '500.00', datetime(2017, 2, 1))
+            session.add_all([m2, payment2])
+
+        c_door = Circle('door', 'Door access', False, CircleManagementStyle.SELF_ADMIN)
+        c_chemistry = Circle('bv9-chemist', 'BV9: Chemist', False, CircleManagementStyle.SELF_ADMIN)
+
+        with session.begin(subtransactions=True):
+            with model_support.run_as(a1):
+                c_door.add_member(a1, "")
+                c_chemistry.add_member(a1, "")
+                c_door.add_member(a2, "")
+                session.add_all([c_door, c_chemistry])
+                session.flush()
+                logger.info("Setup done")
+
+        with session.begin(subtransactions=True):
+            # a1 is paying member
+            assert StripePayment.is_account_paying_member(a1.id) is True
+            assert authz_management.can_haz_door_access(a1, [door.doors["test-door-1"]]) is True
+            assert authz_management.can_haz_door_access(a1, [door.doors["test-door-2"]]) is True
+            assert authz_management.can_haz_door_access(a1, [door.doors["test-door-3"]]) is False
+            assert authz_management.can_haz_door_access(a1, [
+                door.doors["test-door-2"],
+                door.doors["test-door-1"],
+            ]) is True
+            assert authz_management.can_haz_door_access(a1, [
+                door.doors["test-door-3"],
+                door.doors["test-door-1"],
+            ]) is False
+
+            # a2 is paying member, but not member of bv9-chemist circle
+            assert authz_management.can_haz_door_access(a2, [door.doors["test-door-1"]]) is True
+            assert authz_management.can_haz_door_access(a2, [door.doors["test-door-2"]]) is False
+            assert authz_management.can_haz_door_access(a2, [door.doors["test-door-3"]]) is False
+
+            # a3 is not a paying member
+            assert authz_management.can_haz_door_access(a3, [door.doors["test-door-1"]]) is False
+            assert authz_management.can_haz_door_access(a3, [door.doors["test-door-2"]]) is False
+            assert authz_management.can_haz_door_access(a3, [door.doors["test-door-3"]]) is False
+


### PR DESCRIPTION
We simplify a bit by checking payment and employee status first.
Employee have access to all doors, non-paying members have access to no
doors, so we can get that out of the way first.

Once we have done that, we check better that the account is a member of
at least one of the circles on a door, if there is no overlap of
circles, the whole request is denied.