### PR TITLE
web: make mailto: hrefs include email address

### DIFF
--- a/web/src/p2k16/web/static/admin-account-detail.html
+++ b/web/src/p2k16/web/static/admin-account-detail.html
@@ -16,7 +16,7 @@
     </tr>
     <tr>
       <th>email</th>
-      <td><a href="mailto:{{ ctrl.account.email }}">{{ ctrl.account.account.email }}</a></td>
+      <td><a href="mailto:{{ ctrl.account.account.email }}">{{ ctrl.account.account.email }}</a></td>
     </tr>
     <tr>
       <th>Phone number</th>

--- a/web/src/p2k16/web/static/user-detail.html
+++ b/web/src/p2k16/web/static/user-detail.html
@@ -47,7 +47,7 @@
       <div class="form-group">
         <label class="col-sm-1 control-label">Email</label>
         <div class="col-sm-6">
-          <p class="form-control-static"><a href="mailto:{{ ctrl.account.email }}">{{ ctrl.account.email }}</a></p>
+          <p class="form-control-static"><a href="mailto:{{ ctrl.account.account.email }}">{{ ctrl.account.account.email }}</a></p>
         </div>
       </div>
       <div class="form-group">


### PR DESCRIPTION
some missing '.account's made email links non-copyable, and in one
instance invisible