### PR TITLE
fix: Use better profile list

### DIFF
--- a/web/src/p2k16/web/static/admin-account-list.html
+++ b/web/src/p2k16/web/static/admin-account-list.html
@@ -10,7 +10,6 @@
       <th class="col-sm-3">username</th>
       <th class="col-sm-4">email</th>
       <th class="col-sm-4">name</th>
-      <th class="col-sm-1">fee</th>
       <th class="col-sm-1"></th>
     </tr>
     </thead>
@@ -19,7 +18,6 @@
       <td>{{ p.account.username }}</td>
       <td>{{ p.account.email }}</td>
       <td>{{ p.account.name }}</td>
-      <td>{{ p.membership_fee}}</td>
       <td>
         <a href="#!/admin/account/{{ p.account.id }}">show</a>
       </td>

--- a/web/src/p2k16/web/static/admin.html
+++ b/web/src/p2k16/web/static/admin.html
@@ -6,7 +6,7 @@
   <p>
       <a href="#!/admin/company/new" class="btn btn-default">New company</a>
       <a href="#!/admin/company" class="btn btn-default">Companies</a>
-      <a href="#!/admin/account" class="btn btn-default">Accounts (slow)</a>
+      <a href="#!/admin/account" class="btn btn-default">Accounts (faster)</a>
       <a href="#!/admin/circle" class="btn btn-default">Circles</a>
       <a href="#!/admin/tool" class="btn btn-default">Tools</a>
   </p>

--- a/web/src/p2k16/web/static/p2k16/p2k16.js
+++ b/web/src/p2k16/web/static/p2k16/p2k16.js
@@ -85,7 +85,7 @@
             controllerAs: 'ctrl',
             templateUrl: p2k16_resources.admin_account_list_html,
             resolve: {
-                profiles: CoreDataServiceResolvers.data_profile_list
+                profiles: CoreDataServiceResolvers.data_profile_summary_list
             }
         }).when("/admin/account/:account_id", {
             controller: AdminAccountDetailController,


### PR DESCRIPTION
When listing all accounts for /admin/account, the current query is very
slow because it 1) loads all data for each profile, and 2) the loading
of all profiles is done in a separate query.

As an easy fix, use the non-full version of the account list. With this
change the "fee" column is dropped.

Fixes #130.