### PR TITLE
Fix tool check-in button for other users

### DIFF
--- a/web/src/p2k16/web/static/tool-front-page.html
+++ b/web/src/p2k16/web/static/tool-front-page.html
@@ -23,12 +23,7 @@
     <table class="table tools-buttons-table">
       <tr ng-repeat="tool in ctrl.tools">
         <td class="text-center">
-          <button ng-if="tool.checkout.active && tool.checkout.account != ctrl.my_account" type="submit" class="btn btn-default btn-block btn-danger" id="{{tool.name}} isMine">
-            <span>{{tool.description}}</span>
-            <br>
-            <small class="text-center">{{tool.checkout.username}} - {{tool.checkout.started | date:'short'}}</small>
-          </button>
-          <button ng-if="tool.checkout.active && tool.checkout.account == ctrl.my_account" type="submit" class="btn btn-default btn-block btn-danger" ng-click="ctrl.checkinTool(tool)" id="{{tool.name}} notMine">
+          <button ng-if="tool.checkout.active" type="submit" class="btn btn-default btn-block btn-danger" ng-click="ctrl.checkinTool(tool)" id="{{tool.name}}">
             <strong>{{tool.description}}</strong>
             <br>
             <small class="text-center">{{tool.checkout.username}} - {{tool.checkout.started | date:'short'}}</small>


### PR DESCRIPTION
The button showed when not the checked out user had no action attached
so nothing would happen.

Reduced to one button again since they were the same.

Removed invalid part of the id attribute as it didn't seem to do
anything.