### PR TITLE
Re-enable confirmation for non-owned tools

### DIFF
--- a/web/src/p2k16/web/static/tool-front-page.html
+++ b/web/src/p2k16/web/static/tool-front-page.html
@@ -23,7 +23,12 @@
     <table class="table tools-buttons-table">
       <tr ng-repeat="tool in ctrl.tools">
         <td class="text-center">
-          <button ng-if="tool.checkout.active" type="submit" class="btn btn-default btn-block btn-danger" ng-click="ctrl.checkinTool(tool)" id="{{tool.name}}">
+          <button ng-if="tool.checkout.active && tool.checkout.account != ctrl.my_account" type="submit" class="btn btn-block btn-danger" ng-click="ctrl.checkoutToolConfirm(tool)" id="{{tool.name}}">
+            <strong>{{tool.description}}</strong>
+            <br>
+            <small class="text-center">{{tool.checkout.username}} - {{tool.checkout.started | date:'short'}}</small>
+          </button>
+          <button ng-if="tool.checkout.active && tool.checkout.account == ctrl.my_account" type="submit" class="btn btn-default btn-block" ng-click="ctrl.checkinTool(tool)" id="{{tool.name}}">
             <strong>{{tool.description}}</strong>
             <br>
             <small class="text-center">{{tool.checkout.username}} - {{tool.checkout.started | date:'short'}}</small>


### PR DESCRIPTION
In the UI refresh we lost a confirmation for checking in (or out) a tool that you as the current user did not "own". This re-adds this confirmation.

Fixes #136