### PR TITLE
Return a better error message when missing circle

### DIFF
--- a/web/src/p2k16/web/tool_blueprint.py
+++ b/web/src/p2k16/web/tool_blueprint.py
@@ -108,6 +108,10 @@ def data_tool_add():
 @require_circle_membership("despot")
 def _data_tool_save():
     circle_name = request.json["circle"]
+
+    if not circle_name:
+        raise P2k16UserException("A tool needs a circle")
+
     circle = Circle.find_by_name(circle_name)
 
     if not circle:

--- a/web/src/p2k16/web/utils.py
+++ b/web/src/p2k16/web/utils.py
@@ -5,9 +5,10 @@ from functools import wraps
 from symtable import Function
 
 import flask
+from flask.json import dumps
 import flask_login
 import jsonschema as js
-from flask import abort
+from flask import abort, make_response
 from p2k16.core import P2k16UserException
 from p2k16.core.auth import AuthenticatedAccount
 
@@ -24,7 +25,10 @@ def require_circle_membership(circle_name):
                 abort(401)
 
             if not user.is_in_circle(circle_name):
-                abort(403)
+                error_message = dumps({"message": "You are not a member of circle `{}`, permission denied".format(circle_name)})
+                res = make_response(error_message, 403)
+                res.headers["content-type"] = "application/vnd.error+json"
+                abort(res)
 
             return f(*args, **kwargs)
 


### PR DESCRIPTION
A few places we require a specific circle to perform operations, but the error message you get when that happens is a very generic "read only" message, leaving the user confused.

This will make the error message a better "You are not a member of circle `N`", leaving the user with a path forward.

<img width="396" alt="image" src="https://user-images.githubusercontent.com/23787/194739680-dc56a8d4-0c5a-4fb0-a1ad-cc13fbf29a72.png">
