### PR TITLE
Add support for stripe prorations

### DIFF
--- a/migrations/V001.031__stripe_drop_unique.sql
+++ b/migrations/V001.031__stripe_drop_unique.sql
@@ -1,0 +1,1 @@
+ALTER TABLE stripe_payment DROP CONSTRAINT membership_payment_stripe_id_key;

--- a/web/src/p2k16/core/models.py
+++ b/web/src/p2k16/core/models.py
@@ -421,7 +421,7 @@ class StripePayment(DefaultMixin, db.Model):
     __tablename__ = 'stripe_payment'
     __versioned__ = {}
 
-    stripe_id = Column("stripe_id", String(50), unique=True, nullable=False)
+    stripe_id = Column("stripe_id", String(50), unique=False, nullable=False)
     start_date = Column(DateTime, nullable=False)
     end_date = Column(DateTime, nullable=False)
     amount = Column(Numeric(8, 2), nullable=False)


### PR DESCRIPTION
This closes issue #122 related to how Stripe changed their billing of prorations about 1 year ago.

Finally tested ok in staging. Requires a migration to deploy.
