### PR TITLE
Move membership price from code to stripe model

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ six==1.15.0
 SQLAlchemy==1.3.20
 SQLAlchemy-Continuum==1.3.11
 SQLAlchemy-Utils==0.36.8
-stripe==2.55.1
+stripe==5.5.0
 toml==0.10.2
 typing==3.7.4.3
 urllib3==1.26.6

--- a/web/src/p2k16/web/core_blueprint.py
+++ b/web/src/p2k16/web/core_blueprint.py
@@ -11,7 +11,7 @@ from flask import current_app, abort, Blueprint, render_template, jsonify, reque
 from p2k16.core import P2k16UserException, auth, account_management, badge_management, models, event_management, \
     authz_management
 from p2k16.core.membership_management import member_create_checkout_session, member_customer_portal, \
-    get_membership, get_membership_payments, active_member, get_membership_fee
+    get_membership, get_membership_payments, active_member, get_membership_fee, member_get_tiers
 from p2k16.core.models import Account, Circle, Company, CompanyEmployee, CircleMember, BadgeDescription, \
     CircleManagementStyle, Membership, StripePayment
 from p2k16.core.models import AccountBadge
@@ -494,6 +494,9 @@ def membership_customer_portal():
 
     return jsonify(member_customer_portal(account, base_url))
 
+@registry.route('/membership/tiers')
+def membership_tiers():
+    return jsonify(member_get_tiers())
 
 ###############################################################################
 # Circle

--- a/web/src/p2k16/web/core_blueprint.py
+++ b/web/src/p2k16/web/core_blueprint.py
@@ -11,7 +11,7 @@ from flask import current_app, abort, Blueprint, render_template, jsonify, reque
 from p2k16.core import P2k16UserException, auth, account_management, badge_management, models, event_management, \
     authz_management
 from p2k16.core.membership_management import member_create_checkout_session, member_customer_portal, \
-    get_membership, get_membership_payments, active_member, get_membership_fee, member_get_tiers
+    get_membership, get_membership_payments, active_member, get_membership_fee, member_get_status, member_get_tiers, member_retry_payment
 from p2k16.core.models import Account, Circle, Company, CompanyEmployee, CircleMember, BadgeDescription, \
     CircleManagementStyle, Membership, StripePayment
 from p2k16.core.models import AccountBadge
@@ -497,6 +497,17 @@ def membership_customer_portal():
 @registry.route('/membership/tiers')
 def membership_tiers():
     return jsonify(member_get_tiers())
+
+@registry.route('/membership/status')
+def membership_status():
+    account = flask_login.current_user.account
+    return jsonify(member_get_status(account))
+
+@registry.route('/membership/retry-payment', methods=["POST"])
+def membership_retry_payment():
+    account = flask_login.current_user.account
+
+    return jsonify(member_retry_payment(account))
 
 ###############################################################################
 # Circle

--- a/web/src/p2k16/web/membership_blueprint.py
+++ b/web/src/p2k16/web/membership_blueprint.py
@@ -21,7 +21,7 @@ def setup_stripe(cfg: Mapping[str, str]) -> None:
     webhook_secret = cfg.get('STRIPE_WEBHOOK_SECRET', None)
 
     # The API version routinely contains breaking changes and must be kept in sync with code/library.
-    stripe.api_version = '2020-08-27'
+    stripe.api_version = '2022-11-15'
 
 
 membership = Blueprint('membership', __name__, template_folder='templates')

--- a/web/src/p2k16/web/static/core-data-service.js
+++ b/web/src/p2k16/web/static/core-data-service.js
@@ -98,6 +98,21 @@ function CoreDataService($http) {
         return $http(req);
     };
 
+    this.membership_status = function () {
+        var req = {};
+        req.method = 'GET';
+        req.url = '/membership/status';
+        return $http(req);
+    };
+
+    this.membership_retry_payment = function (payload) {
+        var req = {};
+        req.method = 'POST';
+        req.url = '/membership/retry-payment';
+        req.data = payload;
+        return $http(req);
+    };
+
     this.data_circle = function (circle_id) {
         var req = {};
         req.method = 'GET';
@@ -223,6 +238,9 @@ CoreDataServiceResolvers.data_account_summary = function (CoreDataService, $rout
 };
 CoreDataServiceResolvers.membership_tiers = function (CoreDataService) {
   return CoreDataService.membership_tiers().then(function (res) { return res.data; });
+};
+CoreDataServiceResolvers.membership_status = function (CoreDataService) {
+  return CoreDataService.membership_status().then(function (res) { return res.data; });
 };
 CoreDataServiceResolvers.data_circle = function (CoreDataService, $route) {
   var circle_id = $route.current.params.circle_id;

--- a/web/src/p2k16/web/static/core-data-service.js
+++ b/web/src/p2k16/web/static/core-data-service.js
@@ -91,6 +91,13 @@ function CoreDataService($http) {
         return $http(req);
     };
 
+    this.membership_tiers = function () {
+        var req = {};
+        req.method = 'GET';
+        req.url = '/membership/tiers';
+        return $http(req);
+    };
+
     this.data_circle = function (circle_id) {
         var req = {};
         req.method = 'GET';
@@ -213,6 +220,9 @@ CoreDataServiceResolvers.data_account = function (CoreDataService, $route) {
 CoreDataServiceResolvers.data_account_summary = function (CoreDataService, $route) {
   var account_id = $route.current.params.account_id;
   return CoreDataService.data_account_summary(account_id).then(function (res) { return res.data; });
+};
+CoreDataServiceResolvers.membership_tiers = function (CoreDataService) {
+  return CoreDataService.membership_tiers().then(function (res) { return res.data; });
 };
 CoreDataServiceResolvers.data_circle = function (CoreDataService, $route) {
   var circle_id = $route.current.params.circle_id;

--- a/web/src/p2k16/web/static/front-page.html
+++ b/web/src/p2k16/web/static/front-page.html
@@ -5,60 +5,25 @@
       <h2 class="text-center">Pick membership type</h2>
       <br>
         <div class="row text-center align-items-end">
-          <div class="col-lg-6 mb-5 mb-lg-0">
-            <div class="panel panel-info p-5 rounded-lg shadow panel-clickable" ng-click="ctrl.signup(500)">
+          <div ng-repeat="tier in ctrl.membership_tiers" class="col-lg-6 mb-5 mb-lg-0">
+            <div class="panel panel-info p-5 rounded-lg shadow panel-clickable" ng-click="ctrl.signup(tier)">
               <br>
-              <h5 class="text-uppercase font-weight-bold mb-4 text-primary">Standard member</h5>
-              <h2 class="h1 font-weight-bold text-primary">500 kr</h2>
+              <h5 class="text-uppercase font-weight-bold mb-4 text-primary"> {{ tier.name | uppercase }} </h5>
+              <h2 class="h1 font-weight-bold text-primary"> {{ tier.price }} kr</h2>
               <h4 class="text-small font-weight-normal ml-2 text-primary">monthly</h4>
               <br>
               <div class="my-4 mx-auto primary"></div>
+
               <ul class="my-5 text-small text-left">
-                <li class="mb-3">
-                  <i class="mr-2 text-primary"></i> Access to Bitraf 24/7 </li>
-                <li class="mb-3">
-                  <i class="mr-2 text-primary"></i> Open all doors and use all tools </li>
-                <li class="mb-3">
-                  <i class="mr-2 text-primary"></i> Join safety courses</li>
-                <li class="mb-3">
-                  <i class="mr-2 text-primary"></i> Personal box for storage</li>
-                <li class="mb-3">
-                  <i class="mr-2 text-primary"></i> Cancel any time</li>
-                <li class="mb-3">
-                  <i class="mr-2 text-primary"></i> Support Bitraf</li>
+                <li ng-repeat="feature in tier.features" class="mb-3">
+                  <i class="mr-2 text-primary"></i> {{ feature }} </li>
+                </li>
+
                 <p></p>
                 <b>Bitraf is funded by its members!</b>
               </ul>
               <br>
-              <button ng-click="ctrl.signup(500)" class="btn btn-primary btn-block p-2 shadow rounded-pill">Proceed to payment</button>
-            </div>
-          </div>
-          <div class="col-lg-6 mb-5 mb-lg-0">
-            <div class="panel panel-info p-5 rounded-lg shadow panel-clickable" ng-click="ctrl.signup(300)">
-              <br>
-              <h5 class="text-uppercase font-weight-bold mb-4">Supporting member</h5>
-              <h2 class="h1 font-weight-bold">300 kr</h2>
-              <h4 class="text-small font-weight-normal ml-2">monthly</h4>
-              <br>
-              <div class="my-4 mx-auto primary"></div>
-              <ul class="my-5 text-small text-left">
-                <li class="mb-3">
-                  <i class="mr-2 text-primary"></i><em>For students</em></li>
-                <li class="mb-3">
-                  <i class="mr-2 text-primary"></i><em>For the unemployed</em></li>
-                <li class="mb-3">
-                  <i class="mr-2 text-primary"></i><em>For those who cannot afford the full fee</em></li>
-                <li class="mb-3">
-                  <i class="mr-2 text-primary bold"></i>Same benefits as standard members</li>
-                <li class="mb-3">
-                  <i class="mr-2 text-primary"></i> Cancel any time</li>
-                <li class="mb-3">
-                  <i class="mr-2 text-primary"></i> Support Bitraf</li>
-                <p></p>
-                <b>Bitraf is funded by its members!</b>
-              </ul>
-              <br>
-              <button ng-click="ctrl.signup(300)" class="btn btn-primary btn-block p-2 shadow rounded-pill">Proceed to payment</button>
+              <button ng-click="ctrl.signup(tier)" class="btn btn-primary btn-block p-2 shadow rounded-pill">Proceed to payment</button>
             </div>
           </div>
         </div>

--- a/web/src/p2k16/web/static/front-page.html
+++ b/web/src/p2k16/web/static/front-page.html
@@ -1,7 +1,7 @@
 <p2k16-header active="front-page"></p2k16-header>
 
 <div class="container col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3">
-  <section ng-if="!ctrl.employed && !ctrl.payingMember">
+  <section ng-if="!ctrl.employed && !ctrl.payingMember && !ctrl.pendingPayment">
       <h2 class="text-center">Pick membership type</h2>
       <br>
         <div class="row text-center align-items-end">
@@ -27,6 +27,20 @@
             </div>
           </div>
         </div>
+  </section>
+
+  <section ng-if="!ctrl.employed && ctrl.pendingPayment">
+      <h2 class="text-center">Missing payment</h2>
+      <br>
+    <div class="panel panel-danger">
+      <div class="panel-heading text-center">
+        <h4 class="panel-title">Your membership is active, but we are missing a payment</h4>
+      </div>
+      <div class="panel-body text-center">
+        <a class="btn btn-primary" ng-click="ctrl.retryPayment()">Retry payment</a>
+        <a class="btn btn-primary" ng-click="ctrl.manageBilling()">Manage you membership</a>
+      </div>
+    </div>
   </section>
 
   <section ng-if="!ctrl.doorsAvailable">

--- a/web/src/p2k16/web/static/p2k16/p2k16.js
+++ b/web/src/p2k16/web/static/p2k16/p2k16.js
@@ -30,7 +30,8 @@
             controllerAs: 'ctrl',
             templateUrl: p2k16_resources.front_page_html,
             resolve: {
-                recent_events: CoreDataServiceResolvers.recent_events
+                recent_events: CoreDataServiceResolvers.recent_events,
+                membership_tiers: CoreDataServiceResolvers.membership_tiers
             }
         }).when("/about", {
             controller: AboutController,
@@ -639,8 +640,9 @@
      * @param {DoorDataService} DoorDataService
      * @param {P2k16} P2k16
      * @param recent_events
+     * @param membership_tiers
      */
-    function FrontPageController(DoorDataService, P2k16, recent_events, CoreDataService) {
+    function FrontPageController(DoorDataService, P2k16, recent_events, membership_tiers, CoreDataService) {
         var self = this;
 
         self.openDoors = function (doors) {
@@ -650,8 +652,9 @@
             });
         };
         
-        self.signup = function (price) {
-            priceId = 'medlem' + price;
+        self.signup = function (tier) {
+            priceId = tier.priceId;
+
             CoreDataService.membership_create_checkout_session({baseUrl: window.location.origin, priceId:priceId}).then(function (res) {
                 window.stripe.redirectToCheckout(res.data);
             });
@@ -663,6 +666,7 @@
         self.payingMember = profile.is_paying_member;
         self.employed = profile.is_employed;
 
+        self.membership_tiers = membership_tiers;
         self.recent_events = recent_events;
     }
 
@@ -670,16 +674,6 @@
         var self = this;
 
         self.gitRevision = window.gitRevision;
-    }
-
-    function getMembershipTypes() {
-        // TODO: Move this to model
-        return [
-            {plan: 'medlem1500', name: 'Filantropmedlemskap (1500 kr)', price: 1500},
-            {plan: 'medlem500', name: 'Vanlig medlemskap (500 kr)', price: 500},
-            {plan: 'medlem300', name: 'Støttemedlemskap (300 kr)', price: 300},
-            {plan: 'none', name: 'Inaktiv (0 kr)', price: 0}
-        ];
     }
 
     /**

--- a/web/src/p2k16/web/static/p2k16/p2k16.js
+++ b/web/src/p2k16/web/static/p2k16/p2k16.js
@@ -659,7 +659,21 @@
                 window.stripe.redirectToCheckout(res.data);
             });
         };
-        
+
+        self.manageBilling = function () {
+            CoreDataService.membership_customer_portal({ baseUrl: window.location.origin }).then(function (res) {
+                window.location.href = res.data.portalUrl;
+            });
+        };
+
+        self.retryPayment = function () {
+            CoreDataService.membership_retry_payment().then(function (res) {
+                setTimeout(function(){
+                    window.location.reload();
+                 }, 2000);
+            });
+        };
+
         var profile = P2k16.currentProfile();
         self.doorsAvailable = profile.has_door_access;
         self.availableDoors = profile.available_doors;
@@ -668,6 +682,16 @@
 
         self.membership_tiers = membership_tiers;
         self.recent_events = recent_events;
+
+        self.pendingPayment = false;
+        if (!profile.is_paying_member) {
+            // For non-paying members, we should check if the user has unpaid invoices / an active subscription
+            // This can happen if credit expires or unsufficient funds.
+            // In this case, the signup should not be shown.
+            CoreDataService.membership_status().then(function(res) {
+                self.pendingPayment = res.data.subscription_active;
+            });
+        }
     }
 
     function AboutController() {


### PR DESCRIPTION
This is the first of a 2-stage approach to increase the membership prices as voted on in the general assembly. The second stage will adjust prices for existing members.

Membership prices are now managed as Stripe products and can be updated there in the future. Stripe also contain the associated 'features' listed on the front page.

This PR also closes #124 by adding a retry payment button on the front page if there are unpaid invoices.

Tested for regressions on staging.