### PR TITLE
Change to new venv version + source

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ make sure that you have the correct versions.
 
 **IMPORTANT** - Before running any commands, you have to source our setup script:
 
-    # . .settings.sh
+    # source .settings.sh
 
 Creating the database:
 

--- a/bin/p2k16-run-web
+++ b/bin/p2k16-run-web
@@ -9,7 +9,7 @@ basedir="${bin%/*}"
 
 if [[ ! -d env ]]
 then
-    virtualenv -p python3 env
+    python3 -m venv env
 fi
 
 env/bin/pip install -r requirements.txt


### PR DESCRIPTION
The old virtualenv package is deprecated, and not updated anymore, and breaks with new setuptools

source works better on zsh, and also works on bash, so change README to use that method