### PR TITLE
fix: limit characters [+@.] from allowed usernames on registration and e-mail validation

### DIFF
--- a/web/src/p2k16/core/account_management.py
+++ b/web/src/p2k16/core/account_management.py
@@ -185,8 +185,8 @@ def register_account(username: str, email: str, name: str, password: str, phone:
     if " " in username:
         raise P2k16UserException("Username cannot contain spaces")
 
-    if not re.match(r"^[a-zA-Z0-9@._+-]+$", username):
-        raise P2k16UserException("Username can only contain a-z, 0-9, @, ., _, + and -.")
+    if not re.match(r"^[A-z0-9_-]+$", username):
+        raise P2k16UserException("Username can only contain a-z, 0-9, _ and -.")
 
     account = Account(username, email, name, phone, password)
     db.session.add(account)

--- a/web/src/p2k16/core/account_management.py
+++ b/web/src/p2k16/core/account_management.py
@@ -187,7 +187,10 @@ def register_account(username: str, email: str, name: str, password: str, phone:
 
     if not re.match(r"^[A-z0-9_-]+$", username):
         raise P2k16UserException("Username can only contain a-z, 0-9, _ and -.")
-
+    
+    if not re.match(r"^[\w\.\-]+@([\w-]+\.)+[\w-]{2,4}$", email):
+        raise P2k16UserException("Email is not valid!")
+    
     account = Account(username, email, name, phone, password)
     db.session.add(account)
     return account


### PR DESCRIPTION
We can make sure that new members don't use e-mail as username, does not solve the current users with email as username.
Also added e-mail validation to make sure people enter a valid email when registering.

Should consider adding the restrictions to the db as well at some point.